### PR TITLE
changed ontology related column names

### DIFF
--- a/ontology_mappings/cell_type_condition_mapping.tsv
+++ b/ontology_mappings/cell_type_condition_mapping.tsv
@@ -1,4 +1,4 @@
-study	qtl_group	condition	condition_label	cell_type	ontology_term	ontology_label
+study	qtl_group	condition	condition_label	cell_type	tissue_ontology_id	tissue_ontology_term
 BLUEPRINT	monocyte	naive	naive	monocyte	CL_0002057	"CD14-positive, CD16-negative classical monocyte"
 BLUEPRINT	neutrophil	naive	naive	neutrophil	CL_0000775	neutrophil
 BLUEPRINT	T-cell	naive	naive	T-cell	CL_0000624	"CD4-positive, alpha-beta T cell"

--- a/ontology_mappings/friendly_names.tsv
+++ b/ontology_mappings/friendly_names.tsv
@@ -1,4 +1,4 @@
-ontology_term	ontology_label	ontology_tissue
+tissue_ontology_id	tissue_ontology_term	tissue_label
 CL_0002057	CD14-positive, CD16-negative classical monocyte	monocyte
 CL_0000775	neutrophil	neutrophil
 CL_0000624	CD4-positive, alpha-beta T cell	CD4+ T cell

--- a/ontology_mappings/tissue_ontology_mapping.tsv
+++ b/ontology_mappings/tissue_ontology_mapping.tsv
@@ -1,4 +1,4 @@
-study	cell_type	qtl_group	ontology_term	ontology_label
+study	cell_type	qtl_group	tissue_ontology_id	tissue_ontology_term
 BLUEPRINT	monocyte	monocyte	CL_0002057	"CD14-positive, CD16-negative classical monocyte"
 BLUEPRINT	neutrophil	neutrophil	CL_0000775	neutrophil
 BLUEPRINT	T-cell	T-cell	CL_0000624	"CD4-positive, alpha-beta T cell"


### PR DESCRIPTION
Changed the ontology names as following
(ontology_term <-> tissue_ontology_id)
(ontology_label <-> tissue_ontology_term) 
(ontology_tissue <-> tissue_label)

now it is more consistent with 
https://github.com/eQTL-Catalogue/eQTL-Catalogue-resources/blob/master/tabix/tabix_ftp_paths.tsv

Still there is a minor difference with API 
![image](https://user-images.githubusercontent.com/34273025/102798857-5d1b9980-43ba-11eb-99fd-07970eff35d6.png)

`tissue_ontology_id`  is named as `tissue`

I know that it is better to keep shorter names in API. May be we should change tissue_ontology_id to just tissue. But in general I am OK with keeping names as it is with this commit

