### PR TITLE
Changing method to detect null data frames

### DIFF
--- a/tutorials/tabix_use_case.Rmd
+++ b/tutorials/tabix_use_case.Rmd
@@ -184,7 +184,11 @@ summary_list = purrr::map(ftp_path_list, ~safe_import(., region, selected_gene_i
 
 #Extract successful results
 result_list = purrr::map(summary_list, ~.$result)
-result_list = result_list[!unlist(purrr::map(result_list, is.null))]
+
+tissue_noDATA = function(df) {
+  is.data.frame(df) && nrow(df) == 0
+} 
+result_list = result_list[!unlist(purrr::map(result_list, ~tissue_noDATA(.)))]
 
 #Download failed
 message("Download failed for: ")
@@ -214,7 +218,11 @@ summary_list = purrr::map(ftp_path_list, ~safe_import(., region, selected_gene_i
 
 #Extract successful results
 result_list = purrr::map(summary_list, ~.$result)
-result_list = result_list[!unlist(purrr::map(result_list, is.null))]
+
+tissue_noDATA = function(df) {
+  is.data.frame(df) && nrow(df) == 0
+} 
+result_list = result_list[!unlist(purrr::map(result_list, ~tissue_noDATA(.)))]
 
 #Download failed
 message("Download failed for: ")


### PR DESCRIPTION
# is.null method does not work to check empty data tibbles
result_list = result_list[!unlist(purrr::map(result_list, is.null))]

$BLUEPRINT_monocyte
# A tibble: 0 x 20
# … with 20 variables: molecular_trait_id <chr>, chromosome <int>,
#   position <int>, ref <chr>, alt <chr>, variant <chr>, ma_samples <int>,
#   maf <dbl>, pvalue <dbl>, beta <dbl>, se <dbl>, type <chr>, ac <int>,
#   an <int>, r2 <lgl>, molecular_trait_object_id <chr>, gene_id <chr>,
#   median_tpm <dbl>, id <chr>, row_count <int>
> is.null(result_list$BLUEPRINT_monocyte)
[1] FALSE